### PR TITLE
Add full typing support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.21"
+          version: "0.4.27"
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [build]
     environment:
       name: release
-      url: https://pypi.org/p/coqui-tts-coqpit
+      url: https://pypi.org/p/coqpit-config
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.21"
+          version: "0.4.27"
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
       - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+uv.lock
+
 WadaSNR/
 .idea/
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.12.0
+    hooks:
+      - id: mypy
+        args: [--strict]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,5 @@ repos:
     hooks:
       - id: mypy
         args: [--strict]
+        additional_dependencies:
+          - "pytest"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-include README.md
-include LICENSE.txt
-recursive-include coqpit *.json
-recursive-include coqpit *.html
-recursive-include coqpit *.png
-recursive-include coqpit *.md
-recursive-include coqpit *.py
-recursive-include coqpit *.pyx
-recursive-include images *.png

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 [![CI](https://github.com/idiap/coqui-ai-coqpit/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/idiap/coqui-ai-coqpit/actions/workflows/main.yml)
 
-Simple, light-weight and no dependency config handling through python data classes with to/from JSON serialization/deserialization.
+Simple, light-weight and no dependency config handling through python data
+classes with to/from JSON serialization/deserialization.
 
-Currently it is being used by [🐸TTS](https://github.com/idiap/coqui-ai-TTS).
+Fork of the [original, unmaintained repository](https://github.com/coqui-ai/coqpit). New PyPI package: [coqpit-config](https://pypi.org/project/coqpit-config)
+
+Currently it is being used by [coqui-tts](https://github.com/idiap/coqui-ai-TTS).
 
 ## ❔ Why I need this
 What I need from a ML configuration library...

--- a/coqpit/__init__.py
+++ b/coqpit/__init__.py
@@ -1,8 +1,7 @@
 import importlib.metadata
-from dataclasses import dataclass
 
 from coqpit.coqpit import MISSING, Coqpit, check_argument
 
-__all__ = ["dataclass", "MISSING", "Coqpit", "check_argument"]
+__all__ = ["MISSING", "Coqpit", "check_argument"]
 
 __version__ = importlib.metadata.version("coqpit")

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -384,7 +384,7 @@ class Serializable:
             o[field.name] = value
         return o
 
-    def deserialize(self, data: dict) -> "Serializable":
+    def deserialize(self, data: dict[str, Any]) -> Self:
         """Parse input dictionary and deserialize its fields to a dataclass.
 
         Returns:
@@ -416,7 +416,7 @@ class Serializable:
         return self
 
     @classmethod
-    def deserialize_immutable(cls, data: dict) -> "Serializable":
+    def deserialize_immutable(cls, data: dict[str, Any]) -> Self:
         """Parse input dictionary and deserialize its fields to a dataclass.
 
         Returns:
@@ -679,7 +679,7 @@ class Coqpit(Serializable, MutableMapping):
     def has(self, arg: str) -> bool:
         return arg in vars(self)
 
-    def copy(self):
+    def copy(self) -> Self:
         return replace(self)
 
     def update(self, new: dict, allow_new: bool = False) -> None:
@@ -708,7 +708,7 @@ class Coqpit(Serializable, MutableMapping):
         self = self.deserialize(data)  # pylint: disable=self-cls-assignment
 
     @classmethod
-    def new_from_dict(cls: Serializable, data: dict) -> "Coqpit":
+    def new_from_dict(cls, data: dict[str, Any]) -> Self:
         return cls.deserialize_immutable(data)
 
     def to_json(self) -> str:
@@ -747,7 +747,7 @@ class Coqpit(Serializable, MutableMapping):
         cls,
         args: argparse.Namespace | list[str] | None = None,
         arg_prefix: str = "coqpit",
-    ) -> "Coqpit":
+    ) -> Self:
         """Create a new Coqpit instance from argparse input.
 
         Args:

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -215,7 +215,7 @@ def _deserialize_union(x: Any, field_type: type) -> Any:
         field_type (Type): field type.
 
     Returns:
-        [Any]: desrialized value.
+        [Any]: deserialized value.
     """
     for arg in field_type.__args__:
         # stop after first matching type in Union
@@ -251,7 +251,7 @@ def _deserialize_primitive_types(x: Union[int, float, str, bool], field_type: ty
 
 
 def _deserialize(x: Any, field_type: Any) -> Any:
-    """Pick the right desrialization for the given object and the corresponding field type.
+    """Pick the right deserialization for the given object and the corresponding field type.
 
     Args:
         x (object): object to be deserialized.
@@ -374,7 +374,7 @@ class Serializable:
         return o
 
     def deserialize(self, data: dict) -> "Serializable":
-        """Parse input dictionary and desrialize its fields to a dataclass.
+        """Parse input dictionary and deserialize its fields to a dataclass.
 
         Returns:
             self: deserialized `self`.
@@ -406,7 +406,7 @@ class Serializable:
 
     @classmethod
     def deserialize_immutable(cls, data: dict) -> "Serializable":
-        """Parse input dictionary and desrialize its fields to a dataclass.
+        """Parse input dictionary and deserialize its fields to a dataclass.
 
         Returns:
             Newly created deserialized object.
@@ -854,7 +854,9 @@ class Coqpit(Serializable, MutableMapping):
         help_prefix="",
         relaxed_parser: bool = False,
     ) -> argparse.ArgumentParser:
-        """Pass Coqpit fields as argparse arguments. This allows to edit values through command-line.
+        """Create an argparse parser that can parse the Coqpit fields.
+
+        This allows to edit values through command-line.
 
         Args:
             parser (argparse.ArgumentParser, optional): argparse.ArgumentParser instance. If unspecified a new one will be created.

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -167,7 +167,7 @@ def _serialize(x: Any) -> Any:
     if isinstance(x, Serializable) or issubclass(type(x), Serializable):
         return x.serialize()
     if isinstance(x, type) and issubclass(x, Serializable):
-        return x.serialize(x)
+        return x.serialize(x())
     return x
 
 

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -714,8 +714,8 @@ class Coqpit(Serializable, MutableMapping):
         # return asdict(self)
         return self.serialize()
 
-    def from_dict(self, data: dict) -> None:
-        self = self.deserialize(data)  # pylint: disable=self-cls-assignment
+    def from_dict(self, data: dict[str, Any]) -> None:
+        self.deserialize(data)
 
     @classmethod
     def new_from_dict(cls, data: dict[str, Any]) -> Self:
@@ -748,8 +748,7 @@ class Coqpit(Serializable, MutableMapping):
         with open(file_name, encoding="utf8") as f:
             input_str = f.read()
             dump_dict = json.loads(input_str)
-        # TODO: this looks stupid 💆
-        self = self.deserialize(dump_dict)  # pylint: disable=self-cls-assignment
+        self.deserialize(dump_dict)
         self.check_values()
 
     @classmethod

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -370,9 +370,7 @@ class Serializable:
     def validate(self) -> None:
         """Validate if object can serialize / deserialize correctly."""
         self._validate_contracts()
-        if self != self.__class__.deserialize(  # pylint: disable=no-value-for-parameter
-            json.loads(json.dumps(self.serialize())),
-        ):
+        if self != self.__class__().deserialize(json.loads(json.dumps(self.serialize()))):
             msg = "could not be deserialized with same value"
             raise ValueError(msg)
 
@@ -423,7 +421,7 @@ class Serializable:
                 init_kwargs[field.name] = value
                 continue
             if value == MISSING:
-                msg = f"deserialized with unknown value for {field.name} in {self.__name__}"
+                msg = f"deserialized with unknown value for {field.name} in {self.__class__.__name__}"
                 raise ValueError(msg)
             value = _deserialize(value, field.type)
             init_kwargs[field.name] = value

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -706,19 +706,29 @@ class Coqpit(Serializable, CoqpitType):
     def copy(self) -> Self:
         return replace(self)
 
-    def update(self, new: dict, allow_new: bool = False) -> None:
+    @overload
+    def update(self, other: SupportsKeysAndGetItem[str, CoqpitNestedValue], /, **kwargs: CoqpitNestedValue) -> None: ...
+    @overload
+    def update(self, other: Iterable[tuple[str, CoqpitNestedValue]], /, **kwargs: CoqpitNestedValue) -> None: ...
+    @overload
+    def update(self, /, **kwargs: CoqpitNestedValue) -> None: ...
+    def update(self, other: Any = (), /, **kwargs: CoqpitNestedValue) -> None:
         """Update Coqpit fields by the input ```dict```.
 
         Args:
-            new (dict): dictionary with new values.
-            allow_new (bool, optional): allow new fields to add. Defaults to False.
+            other (dict): dictionary with new values.
         """
-        for key, value in new.items():
-            if allow_new or hasattr(self, key):
+        if isinstance(other, dict):
+            for key in other:
+                setattr(self, key, other[key])
+        elif hasattr(other, "keys"):
+            for key in other.keys():
+                setattr(self, key, other[key])
+        else:
+            for key, value in other:
                 setattr(self, key, value)
-            else:
-                msg = f" [!] No key - {key}"
-                raise KeyError(msg)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def pprint(self) -> None:
         """Print Coqpit fields in a format."""

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -201,7 +201,7 @@ def _deserialize_dict(x: dict[Any, Any]) -> dict[Any, Any]:
     return out_dict
 
 
-def _deserialize_list(x: list[_T], field_type: FieldType) -> list[_T]:
+def _deserialize_list(x: list[Any], field_type: FieldType) -> list[Any]:
     """Deserialize values for List typed fields.
 
     Args:

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -111,13 +111,6 @@ def safe_issubclass(cls, classinfo) -> bool:
         return r
 
 
-def _coqpit_json_default(obj: Any) -> Any:
-    if isinstance(obj, Path):
-        return str(obj)
-    msg = f"Can't encode object of type {type(obj).__name__}"
-    raise TypeError(msg)
-
-
 def _default_value(x: Field[_T]) -> _T | Literal[_MISSING_TYPE.MISSING]:
     """Return the default value of the input Field.
 
@@ -713,7 +706,7 @@ class Coqpit(Serializable, MutableMapping):
 
     def to_json(self) -> str:
         """Returns a JSON string representation."""
-        return json.dumps(asdict(self), indent=4, default=_coqpit_json_default)
+        return json.dumps(self.to_dict(), indent=4)
 
     def save_json(self, file_name: str | os.PathLike[Any]) -> None:
         """Save Coqpit to a json file.
@@ -722,7 +715,7 @@ class Coqpit(Serializable, MutableMapping):
             file_name (str): path to the output json file.
         """
         with open(file_name, "w", encoding="utf8") as f:
-            json.dump(asdict(self), f, indent=4)
+            json.dump(self.to_dict(), f, indent=4)
 
     def load_json(self, file_name: str | os.PathLike[Any]) -> None:
         """Load a json file and update matching config fields with type checking.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 [tool.uv]
 dev-dependencies = [
     "coverage>=7",
+    "mypy>=1.12.0",
     "pre-commit>=3",
     "pytest>=8",
     "ruff==0.6.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqpit"
-version = "0.0.17"
+version = "0.1.0"
 description = "Simple (maybe too simple), light-weight config management through python data-classes."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages.find]
-include = ["coqpit*"]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "coqpit"
@@ -47,6 +44,15 @@ dev-dependencies = [
 [project.urls]
 Repository = "https://github.com/idiap/coqui-ai-coqpit"
 Issues = "https://github.com/idiap/coqui-ai-coqpit/issues"
+
+[tool.hatch.build]
+exclude = [
+    "/.github",
+    "/.gitignore",
+    "/.pre-commit-config.yaml",
+    "/Makefile",
+    "/tests",
+]
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,22 @@ exclude = [
 [tool.ruff]
 target-version = "py39"
 line-length = 120
-lint.extend-select = ["I", "UP", "B", "W", "A", "PLC", "PLE"]
+lint.select = ["ALL"]
+lint.ignore = [
+    "ANN401",
+    "D104",
+    "FIX",
+    "TD",
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "D",
+    "FA100",
+    "PLR2004",
+    "S101",
+    "T201",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,6 @@ convention = "google"
     "FA100",
     "PLR2004",
     "S101",
+    "SLF001",
     "T201",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "typing_extensions>=4.10",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "coverage>=7",
     "mypy>=1.12.0",
     "pre-commit>=3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
 ]
-dependencies = []
+dependencies = [
+    "typing_extensions>=4.10",
+]
 
 [tool.uv]
 dev-dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-from setuptools import setup
-
-setup()

--- a/tests/test_copying.py
+++ b/tests/test_copying.py
@@ -9,7 +9,7 @@ class SimpleConfig(Coqpit):
     val_a: int = 10
 
 
-def test_copying():
+def test_copying() -> None:
     config = SimpleConfig()
 
     config_new = config.copy()

--- a/tests/test_init_from_dict.py
+++ b/tests/test_init_from_dict.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass, field
+from typing import Optional
 
 from coqpit import Coqpit
 
 
 @dataclass
 class Person(Coqpit):
-    name: str = None
-    age: int = None
+    name: Optional[str] = None
+    age: Optional[int] = None
 
 
 @dataclass
@@ -28,7 +29,7 @@ class WithRequired(Coqpit):
     name: str
 
 
-def test_new_from_dict():
+def test_new_from_dict() -> None:
     ref_config = Reference(name="Fancy", size=3**10, people=[Person(name="Anonymous", age=42)])
 
     new_config = Reference.new_from_dict({"name": "Fancy", "size": 3**10, "people": [{"name": "Anonymous", "age": 42}]})

--- a/tests/test_init_from_dict.py
+++ b/tests/test_init_from_dict.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
+import pytest  # type: ignore[import-not-found]
+
 from coqpit import Coqpit
 
 
@@ -19,7 +21,7 @@ class Reference(Coqpit):
             Person(name="Eren", age=11),
             Person(name="Geren", age=12),
             Person(name="Ceren", age=15),
-        ]
+        ],
     )
     people_ids: list[int] = field(default_factory=lambda: [1, 2, 3])
 
@@ -41,7 +43,5 @@ def test_new_from_dict() -> None:
     assert ref_config.people[0].name == new_config.people[0].name
     assert ref_config.people[0].age == new_config.people[0].age
 
-    try:
+    with pytest.raises(ValueError, match="Missing required field"):
         WithRequired.new_from_dict({})
-    except ValueError as e:
-        assert "Missing required field" in e.args[0]

--- a/tests/test_init_from_dict.py
+++ b/tests/test_init_from_dict.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-import pytest  # type: ignore[import-not-found]
+import pytest
 
 from coqpit import Coqpit
 

--- a/tests/test_merge_configs.py
+++ b/tests/test_merge_configs.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from coqpit.coqpit import Coqpit
 
@@ -6,7 +7,7 @@ from coqpit.coqpit import Coqpit
 @dataclass
 class CoqpitA(Coqpit):
     val_a: int = 10
-    val_b: int = None
+    val_b: Optional[int] = None
     val_c: str = "Coqpit is great!"
     val_same: float = 10.21
 
@@ -22,21 +23,21 @@ class CoqpitB(Coqpit):
 @dataclass
 class Reference(Coqpit):
     val_a: int = 10
-    val_b: int = None
+    val_b: Optional[int] = None
     val_c: str = "Coqpit is great!"
     val_e: int = 257
     val_f: float = -10.21
     val_g: str = "Coqpit is really great!"
-    val_same: int = 10.21  # duplicate fields are override by the merged Coqpit class.
+    val_same: float = 10.21  # duplicate fields are override by the merged Coqpit class.
 
 
-def test_config_merge():
+def test_config_merge() -> None:
     coqpit_ref = Reference()
     coqpita = CoqpitA()
     coqpitb = CoqpitB()
     coqpitb.merge(coqpita)
     print(coqpitb.val_a)
-    print(coqpitb.pprint())
+    coqpitb.pprint()
 
     assert coqpit_ref.val_a == coqpitb.val_a
     assert coqpit_ref.val_b == coqpitb.val_b

--- a/tests/test_nested_configs.py
+++ b/tests/test_nested_configs.py
@@ -1,5 +1,5 @@
-import os
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Optional, Union
 
 from coqpit import Coqpit, check_argument
@@ -39,16 +39,16 @@ class NestedConfig(Coqpit):
 
 
 def test_nested() -> None:
-    file_path = os.path.dirname(os.path.abspath(__file__))
+    file_path = Path(__file__).resolve().parent / "example_config.json"
     # init 🐸 dataclass
     config = NestedConfig()
 
     # save to a json file
-    config.save_json(os.path.join(file_path, "example_config.json"))
+    config.save_json(file_path)
     # load a json file
     config2 = NestedConfig(val_e=500)
     # update the config with the json file.
-    config2.load_json(os.path.join(file_path, "example_config.json"))
+    config2.load_json(file_path)
     # now they should be having the same values.
     assert config == config2
 

--- a/tests/test_nested_configs.py
+++ b/tests/test_nested_configs.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import asdict, dataclass, field
-from typing import Union
+from typing import Optional, Union
 
 from coqpit import Coqpit, check_argument
 
@@ -8,12 +8,10 @@ from coqpit import Coqpit, check_argument
 @dataclass
 class SimpleConfig(Coqpit):
     val_a: int = 10
-    val_b: int = None
+    val_b: Optional[int] = None
     val_c: str = "Coqpit is great!"
 
-    def check_values(
-        self,
-    ):
+    def check_values(self) -> None:
         """Check config fields"""
         c = asdict(self)
         check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)
@@ -24,15 +22,13 @@ class SimpleConfig(Coqpit):
 @dataclass
 class NestedConfig(Coqpit):
     val_d: int = 10
-    val_e: int = None
+    val_e: Optional[int] = None
     val_f: str = "Coqpit is great!"
-    sc_list: list[SimpleConfig] = None
+    sc_list: Optional[list[SimpleConfig]] = None
     sc: SimpleConfig = field(default_factory=lambda: SimpleConfig())
     union_var: Union[list[SimpleConfig], SimpleConfig] = field(default_factory=lambda: [SimpleConfig(), SimpleConfig()])
 
-    def check_values(
-        self,
-    ):
+    def check_values(self) -> None:
         """Check config fields"""
         c = asdict(self)
         check_argument("val_d", c, restricted=True, min_val=10, max_val=2056)
@@ -42,7 +38,7 @@ class NestedConfig(Coqpit):
         check_argument("sc", c, restricted=True, allow_none=True)
 
 
-def test_nested():
+def test_nested() -> None:
     file_path = os.path.dirname(os.path.abspath(__file__))
     # init 🐸 dataclass
     config = NestedConfig()
@@ -50,19 +46,19 @@ def test_nested():
     # save to a json file
     config.save_json(os.path.join(file_path, "example_config.json"))
     # load a json file
-    config2 = NestedConfig(val_d=None, val_e=500, val_f=None, sc_list=None, sc=None, union_var=None)
+    config2 = NestedConfig(val_e=500)
     # update the config with the json file.
     config2.load_json(os.path.join(file_path, "example_config.json"))
     # now they should be having the same values.
     assert config == config2
 
     # pretty print the dataclass
-    print(config.pprint())
+    config.pprint()
 
     # export values to a dict
     config_dict = config.to_dict()
     # crate a new config with different values than the defaults
-    config2 = NestedConfig(val_d=None, val_e=500, val_f=None, sc_list=None, sc=None, union_var=None)
+    config2 = NestedConfig(val_e=500)
     # update the config with the exported valuess from the previous config.
     config2.from_dict(config_dict)
     # now they should be having the same values.

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -24,10 +24,12 @@ class SimpleConfig(Coqpit):
     empty_int_list: Optional[list[int]] = field(default=None, metadata={"help": "int list without default value"})
     empty_str_list: Optional[list[str]] = field(default=None, metadata={"help": "str list without default value"})
     list_with_default_factory: list[str] = field(
-        default_factory=list, metadata={"help": "str list with default factory"}
+        default_factory=list,
+        metadata={"help": "str list with default factory"},
     )
 
-    # mylist_without_default: List[SimplerConfig] = field(default=None, metadata={'help': 'list of SimplerConfig'})  # NOT SUPPORTED YET!
+    # TODO: not supported yet
+    # mylist_without_default: List[SimplerConfig] = field(default=None)  noqa: ERA001
 
     def check_values(self) -> None:
         """Check config fields"""
@@ -112,7 +114,7 @@ def test_boolean_parse() -> None:
 
     try:
         config.parse_args(args)
-        raise AssertionError("should not reach this")  # pragma: no cover
+        raise AssertionError  # pragma: no cover, should not reach this
     except SystemExit:
         pass
 
@@ -126,7 +128,7 @@ def test_argparse_with_required_field() -> None:
     args = ["--coqpit.val_a", "10"]
     try:
         c = ArgparseWithRequiredField()  # type: ignore[call-arg]
-        raise AssertionError("should not reach this")  # pragma: no cover
+        raise AssertionError  # pragma: no cover, should not reach this
     except TypeError:
         # __init__ should fail due to missing val_a
         pass
@@ -151,7 +153,8 @@ def test_init_argparse_list_and_nested() -> None:
             metadata={"help": "list of SimplerConfig2"},
         )
 
-        # mylist_without_default: List[SimplerConfig2] = field(default=None, metadata={'help': 'list of SimplerConfig2'})  # NOT SUPPORTED YET!
+        # TODO: not supported yet
+        # mylist_without_default: List[SimplerConfig2] = field(default=None)  # noqa: ERA001
 
         def check_values(self) -> None:
             """Check config fields"""

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -70,7 +70,7 @@ def test_parse_argparse() -> None:
     )
 
     # create and init argparser with Coqpit
-    parser = config.init_argparse()
+    parser = config.init_argparse(instance=config)
     parser.print_help()
 
     # parse the argsparser

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -1,36 +1,35 @@
 from dataclasses import asdict, dataclass, field
+from typing import Optional
 
 from coqpit.coqpit import Coqpit, check_argument
 
 
 @dataclass
 class SimplerConfig(Coqpit):
-    val_a: int = field(default=None, metadata={"help": "this is val_a"})
+    val_a: Optional[int] = field(default=None, metadata={"help": "this is val_a"})
 
 
 @dataclass
 class SimpleConfig(Coqpit):
     val_a: int = field(default=10, metadata={"help": "this is val_a of SimpleConfig"})
-    val_b: int = field(default=None, metadata={"help": "this is val_b"})
+    val_b: Optional[int] = field(default=None, metadata={"help": "this is val_b"})
     val_c: str = "Coqpit is great!"
-    val_dict: dict = field(default_factory=lambda: {"val_a": 100, "val_b": 200, "val_c": 300})
+    val_dict: dict[str, int] = field(default_factory=lambda: {"val_a": 100, "val_b": 200, "val_c": 300})
     mylist_with_default: list[SimplerConfig] = field(
         default_factory=lambda: [SimplerConfig(val_a=100), SimplerConfig(val_a=999)],
         metadata={"help": "list of SimplerConfig"},
     )
     int_list: list[int] = field(default_factory=lambda: [1, 2, 3], metadata={"help": "int"})
     str_list: list[str] = field(default_factory=lambda: ["veni", "vidi", "vici"], metadata={"help": "str"})
-    empty_int_list: list[int] = field(default=None, metadata={"help": "int list without default value"})
-    empty_str_list: list[str] = field(default=None, metadata={"help": "str list without default value"})
+    empty_int_list: Optional[list[int]] = field(default=None, metadata={"help": "int list without default value"})
+    empty_str_list: Optional[list[str]] = field(default=None, metadata={"help": "str list without default value"})
     list_with_default_factory: list[str] = field(
         default_factory=list, metadata={"help": "str list with default factory"}
     )
 
     # mylist_without_default: List[SimplerConfig] = field(default=None, metadata={'help': 'list of SimplerConfig'})  # NOT SUPPORTED YET!
 
-    def check_values(
-        self,
-    ):
+    def check_values(self) -> None:
         """Check config fields"""
         c = asdict(self)
         check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)
@@ -38,7 +37,7 @@ class SimpleConfig(Coqpit):
         check_argument("val_c", c, restricted=True)
 
 
-def test_parse_argparse():
+def test_parse_argparse() -> None:
     args = []
     args.extend(["--coqpit.val_a", "222"])
     args.extend(["--coqpit.val_b", "999"])
@@ -54,7 +53,7 @@ def test_parse_argparse():
 
     # initial config
     config = SimpleConfig()
-    print(config.pprint())
+    config.pprint()
 
     # reference config that we like to match with the config above
     config_ref = SimpleConfig(
@@ -81,7 +80,7 @@ def test_parse_argparse():
     assert config == config_ref
 
 
-def test_boolean_parse():
+def test_boolean_parse() -> None:
     @dataclass
     class Config(Coqpit):
         boolean_without_default: bool = field()
@@ -123,7 +122,7 @@ class ArgparseWithRequiredField(Coqpit):
     val_a: int
 
 
-def test_argparse_with_required_field():
+def test_argparse_with_required_field() -> None:
     args = ["--coqpit.val_a", "10"]
     try:
         c = ArgparseWithRequiredField()  # pylint: disable=no-value-for-parameter
@@ -137,16 +136,16 @@ def test_argparse_with_required_field():
     assert c.val_a == 10
 
 
-def test_init_argparse_list_and_nested():
+def test_init_argparse_list_and_nested() -> None:
     @dataclass
     class SimplerConfig2(Coqpit):
-        val_a: int = field(default=None, metadata={"help": "this is val_a"})
+        val_a: Optional[int] = field(default=None, metadata={"help": "this is val_a"})
 
     @dataclass
     class SimpleConfig2(Coqpit):
         val_req: str  # required field
         val_a: int = field(default=10, metadata={"help": "this is val_a of SimpleConfig2"})
-        val_b: int = field(default=None, metadata={"help": "this is val_b"})
+        val_b: Optional[int] = field(default=None, metadata={"help": "this is val_b"})
         nested_config: SimplerConfig2 = field(default_factory=lambda: SimplerConfig2())
         mylist_with_default: list[SimplerConfig2] = field(
             default_factory=lambda: [SimplerConfig2(val_a=100), SimplerConfig2(val_a=999)],
@@ -155,9 +154,7 @@ def test_init_argparse_list_and_nested():
 
         # mylist_without_default: List[SimplerConfig2] = field(default=None, metadata={'help': 'list of SimplerConfig2'})  # NOT SUPPORTED YET!
 
-        def check_values(
-            self,
-        ):
+        def check_values(self) -> None:
             """Check config fields"""
             c = asdict(self)
             check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -112,8 +112,8 @@ def test_boolean_parse() -> None:
 
     try:
         config.parse_args(args)
-        assert False, "should not reach this"  # noqa: B011
-    except:  # noqa: E722
+        raise AssertionError("should not reach this")  # pragma: no cover
+    except SystemExit:
         pass
 
 
@@ -125,9 +125,8 @@ class ArgparseWithRequiredField(Coqpit):
 def test_argparse_with_required_field() -> None:
     args = ["--coqpit.val_a", "10"]
     try:
-        c = ArgparseWithRequiredField()  # pylint: disable=no-value-for-parameter
-        c.parse_args(args)
-        assert False  # noqa: B011
+        c = ArgparseWithRequiredField()  # type: ignore[call-arg]
+        raise AssertionError("should not reach this")  # pragma: no cover
     except TypeError:
         # __init__ should fail due to missing val_a
         pass

--- a/tests/test_parse_known_argparse.py
+++ b/tests/test_parse_known_argparse.py
@@ -1,26 +1,25 @@
 from dataclasses import asdict, dataclass, field
+from typing import Optional
 
 from coqpit.coqpit import Coqpit, check_argument
 
 
 @dataclass
 class SimplerConfig(Coqpit):
-    val_a: int = field(default=None, metadata={"help": "this is val_a"})
+    val_a: Optional[int] = field(default=None, metadata={"help": "this is val_a"})
 
 
 @dataclass
 class SimpleConfig(Coqpit):
     val_a: int = field(default=10, metadata={"help": "this is val_a of SimpleConfig"})
-    val_b: int = field(default=None, metadata={"help": "this is val_b"})
+    val_b: Optional[int] = field(default=None, metadata={"help": "this is val_b"})
     val_c: str = "Coqpit is great!"
     mylist_with_default: list[SimplerConfig] = field(
         default_factory=lambda: [SimplerConfig(val_a=100), SimplerConfig(val_a=999)],
         metadata={"help": "list of SimplerConfig"},
     )
 
-    def check_values(
-        self,
-    ):
+    def check_values(self) -> None:
         """Check config fields"""
         c = asdict(self)
         check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)
@@ -28,7 +27,7 @@ class SimpleConfig(Coqpit):
         check_argument("val_c", c, restricted=True)
 
 
-def test_parse_argparse():
+def test_parse_argparse() -> None:
     unknown_args = ["--coqpit.arg_does_not_exist", "111"]
     args = []
     args.extend(["--coqpit.val_a", "222"])
@@ -40,7 +39,7 @@ def test_parse_argparse():
 
     # initial config
     config = SimpleConfig()
-    print(config.pprint())
+    config.pprint()
 
     # reference config that we like to match with the config above
     config_ref = SimpleConfig(
@@ -62,7 +61,7 @@ def test_parse_argparse():
     assert unknown == unknown_args
 
 
-def test_parse_edited_argparse():
+def test_parse_edited_argparse() -> None:
     """calling `parse_known_argparse` after some modifications in the config values.
     `parse_known_argparse` should keep the modified values if not defined in argv"""
 
@@ -77,7 +76,7 @@ def test_parse_edited_argparse():
     config.val_b = 444
     config.val_c = "this is different"
     config.mylist_with_default[0].val_a = 777
-    print(config.pprint())
+    config.pprint()
 
     # reference config that we like to match with the config above
     config_ref = SimpleConfig(

--- a/tests/test_parse_known_argparse.py
+++ b/tests/test_parse_known_argparse.py
@@ -62,9 +62,9 @@ def test_parse_argparse() -> None:
 
 
 def test_parse_edited_argparse() -> None:
-    """calling `parse_known_argparse` after some modifications in the config values.
-    `parse_known_argparse` should keep the modified values if not defined in argv"""
-
+    """Calling `parse_known_argparse` after some modifications in the config values.
+    `parse_known_argparse` should keep the modified values if not defined in argv
+    """
     unknown_args = ["--coqpit.arg_does_not_exist", "111"]
     args = []
     args.extend(["--coqpit.mylist_with_default.1.val_a", "111"])

--- a/tests/test_relaxed_parse_known_argparse.py
+++ b/tests/test_relaxed_parse_known_argparse.py
@@ -1,31 +1,24 @@
 from dataclasses import asdict, dataclass, field
-from typing import Union
+from typing import Any, Optional, Union
 
 from coqpit.coqpit import Coqpit, check_argument
 
 
 @dataclass
-class SimplerConfig(Coqpit):
-    val_a: int = field(default=None, metadata={"help": "this is val_a"})
-
-
-@dataclass
 class SimpleConfig(Coqpit):
     val_a: int = field(default=10, metadata={"help": "this is val_a of SimpleConfig"})
-    val_b: int = field(default=None, metadata={"help": "this is val_b"})
-    val_c: Union[int, str] = None
-    val_d: list[list] = None
+    val_b: Optional[int] = field(default=None, metadata={"help": "this is val_b"})
+    val_c: Optional[Union[int, str]] = None
+    val_d: Optional[list[list[Any]]] = None
 
-    def check_values(
-        self,
-    ):
+    def check_values(self) -> None:
         """Check config fields"""
         c = asdict(self)
         check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)
         check_argument("val_b", c, restricted=True, min_val=128, max_val=4058, allow_none=True)
 
 
-def test_parse_argparse():
+def test_parse_argparse() -> None:
     unknown_args = ["--coqpit.arg_does_not_exist", "111"]
     args = []
     args.extend(["--coqpit.val_a", "222"])
@@ -34,7 +27,7 @@ def test_parse_argparse():
 
     # initial config
     config = SimpleConfig()
-    print(config.pprint())
+    config.pprint()
 
     # reference config that we like to match with the config above
     config_ref = SimpleConfig(val_a=222, val_b=999, val_c=None, val_d=None)

--- a/tests/test_serialization.json
+++ b/tests/test_serialization.json
@@ -1,6 +1,7 @@
 {
     "name": "Coqpit",
     "size": 3,
+    "path": "a/b",
     "people": [
         {
             "name": "Eren",
@@ -14,5 +15,10 @@
             "name": "Ceren",
             "age": 15
         }
-    ]
+    ],
+    "some_dict": {
+        "a": 1,
+        "b": 2,
+        "c": null
+    }
 }

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,26 +1,30 @@
-import os
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
 
 from coqpit import Coqpit
 
 
 @dataclass
 class Person(Coqpit):
-    name: str = None
-    age: int = None
+    name: Optional[str] = None
+    age: Optional[int] = None
 
 
 @dataclass
 class Group(Coqpit):
-    name: str = None
-    size: int = None
-    people: list[Person] = None
+    name: Optional[str] = None
+    size: Optional[int] = None
+    path: Optional[Path] = None
+    people: list[Person] = field(default_factory=list)
+    some_dict: dict[str, Optional[int]] = field(default_factory=dict)
 
 
 @dataclass
 class Reference(Coqpit):
-    name: str = "Coqpit"
-    size: int = 3
+    name: Optional[str] = "Coqpit"
+    size: Optional[int] = 3
+    path: Path = Path("a/b")
     people: list[Person] = field(
         default_factory=lambda: [
             Person(name="Eren", age=11),
@@ -28,10 +32,11 @@ class Reference(Coqpit):
             Person(name="Ceren", age=15),
         ]
     )
+    some_dict: dict[str, Optional[int]] = field(default_factory=lambda: {"a": 1, "b": 2, "c": None})
 
 
-def test_serizalization():
-    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_serialization.json")
+def test_serialization() -> None:
+    file_path = Path(__file__).resolve().parent / "test_serialization.json"
 
     ref_config = Reference()
     ref_config.save_json(file_path)
@@ -50,3 +55,7 @@ def test_serizalization():
     assert ref_config.people[0].age == new_config.people[0].age
     assert ref_config.people[1].age == new_config.people[1].age
     assert ref_config.people[2].age == new_config.people[2].age
+    assert ref_config.path == new_config.path
+    assert ref_config.some_dict["a"] == new_config.some_dict["a"]
+    assert ref_config.some_dict["b"] == new_config.some_dict["b"]
+    assert ref_config.some_dict["c"] == new_config.some_dict["c"]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -30,7 +30,7 @@ class Reference(Coqpit):
             Person(name="Eren", age=11),
             Person(name="Geren", age=12),
             Person(name="Ceren", age=15),
-        ]
+        ],
     )
     some_dict: dict[str, Optional[int]] = field(default_factory=lambda: {"a": 1, "b": 2, "c": None})
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from coqpit import Coqpit
+from coqpit.coqpit import Coqpit, _deserialize_list
 
 
 @dataclass
@@ -59,3 +59,10 @@ def test_serialization() -> None:
     assert ref_config.some_dict["a"] == new_config.some_dict["a"]
     assert ref_config.some_dict["b"] == new_config.some_dict["b"]
     assert ref_config.some_dict["c"] == new_config.some_dict["c"]
+
+
+def test_deserialize_list() -> None:
+    assert _deserialize_list([1, 2, 3], list) == [1, 2, 3]
+    assert _deserialize_list([1, 2, 3], list[int]) == [1, 2, 3]
+    assert _deserialize_list([1, 2, 3], list[float]) == [1.0, 2.0, 3.0]
+    assert _deserialize_list([1, 2, 3], list[str]) == ["1", "2", "3"]

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -1,5 +1,5 @@
-import os
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Union
 
 from coqpit.coqpit import MISSING, Coqpit, check_argument
@@ -20,7 +20,7 @@ class SimpleConfig(Coqpit):
     # list of list
     val_listoflist: list[list[int]] = field(default_factory=lambda: [[1, 2], [3, 4]])
     val_listofunion: list[list[Union[str, int, bool]]] = field(
-        default_factory=lambda: [[1, 3], [1, "Hi!"], [True, False]]
+        default_factory=lambda: [[1, 3], [1, "Hi!"], [True, False]],
     )
 
     def check_values(
@@ -34,7 +34,7 @@ class SimpleConfig(Coqpit):
 
 
 def test_simple_config() -> None:
-    file_path = os.path.dirname(os.path.abspath(__file__))
+    file_path = Path(__file__).resolve().parent / "example_config.json"
     config = SimpleConfig()
 
     # try MISSING class argument
@@ -47,8 +47,8 @@ def test_simple_config() -> None:
     # try serialization and deserialization
     print(config.serialize())
     print(config.to_json())
-    config.save_json(os.path.join(file_path, "example_config.json"))
-    config.load_json(os.path.join(file_path, "example_config.json"))
+    config.save_json(file_path)
+    config.load_json(file_path)
     config.pprint()
 
     # try `dict` interface

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import asdict, dataclass, field
-from typing import Union
+from typing import Any, Optional, Union
 
 from coqpit.coqpit import MISSING, Coqpit, check_argument
 
@@ -8,7 +8,7 @@ from coqpit.coqpit import MISSING, Coqpit, check_argument
 @dataclass
 class SimpleConfig(Coqpit):
     val_a: int = 10
-    val_b: int = None
+    val_b: Optional[int] = None
     val_d: float = 10.21
     val_c: str = "Coqpit is great!"
     vol_e: bool = True
@@ -16,16 +16,16 @@ class SimpleConfig(Coqpit):
     # raise an error when accessing the value if it is not changed. It is a way to define
     val_k: int = MISSING
     # optional field
-    val_dict: dict = field(default_factory=lambda: {"val_aa": 10, "val_ss": "This is in a dict."})
+    val_dict: dict[str, Any] = field(default_factory=lambda: {"val_aa": 10, "val_ss": "This is in a dict."})
     # list of list
-    val_listoflist: list[list] = field(default_factory=lambda: [[1, 2], [3, 4]])
+    val_listoflist: list[list[int]] = field(default_factory=lambda: [[1, 2], [3, 4]])
     val_listofunion: list[list[Union[str, int, bool]]] = field(
         default_factory=lambda: [[1, 3], [1, "Hi!"], [True, False]]
     )
 
     def check_values(
         self,
-    ):  # you can define explicit constraints on the fields using `check_argument()`
+    ) -> None:  # you can define explicit constraints on the fields using `check_argument()`
         """Check config fields"""
         c = asdict(self)
         check_argument("val_a", c, restricted=True, min_val=10, max_val=2056)
@@ -33,7 +33,7 @@ class SimpleConfig(Coqpit):
         check_argument("val_c", c, restricted=True)
 
 
-def test_simple_config():
+def test_simple_config() -> None:
     file_path = os.path.dirname(os.path.abspath(__file__))
     config = SimpleConfig()
 
@@ -49,7 +49,7 @@ def test_simple_config():
     print(config.to_json())
     config.save_json(os.path.join(file_path, "example_config.json"))
     config.load_json(os.path.join(file_path, "example_config.json"))
-    print(config.pprint())
+    config.pprint()
 
     # try `dict` interface
     print(*config)

--- a/tests/test_simple_config.py
+++ b/tests/test_simple_config.py
@@ -37,12 +37,17 @@ def test_simple_config() -> None:
     file_path = Path(__file__).resolve().parent / "example_config.json"
     config = SimpleConfig()
 
+    assert config._is_initialized()
+
     # try MISSING class argument
     try:
         _ = config.val_k
     except AttributeError:
         print(" val_k needs a different value before accessing it.")
     config.val_k = 1000
+
+    assert "val_a" in config
+    assert config.has("val_a")
 
     # try serialization and deserialization
     print(config.serialize())


### PR DESCRIPTION
This will be the first release of our Coqpit fork. It's a relatively large PR because I added full typing support checked with `mypy --strict` and enabled almost all ruff linter rules. This required some minor changes in functionality so that everything is consistent, but they shouldn't have an effect on Trainer or TTS. Test coverage for Coqpit is also very high. 

In any case, releasing this now is fine because TTS and Trainer need to be manually switched to this fork at a later stage, but I already checked that the Trainer and TTS test suites pass in https://github.com/idiap/coqui-ai-Trainer/pull/10 and https://github.com/idiap/coqui-ai-TTS/pull/110