### PR TITLE
Fix argument parsing, improve test coverage

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,10 @@
+name: Setup uv
+runs:
+  using: 'composite'
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "0.5.1"
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.4.27"
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Lint check

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -19,12 +19,8 @@ jobs:
           if [[ "v$version" != "$tag" ]]; then
             exit 1
           fi
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.4.27"
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
       - name: Set up Python
         run: uv python install
       - name: Build sdist and wheel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 👩‍✈️ Coqpit
 
+[![PyPI - License](https://img.shields.io/pypi/l/coqpit-config)](https://github.com/idiap/coqui-ai-coqpit/blob/main/LICENSE.txt)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/coqpit-config)
+[![PyPI - Version](https://img.shields.io/pypi/v/coqpit-config)](https://pypi.org/project/coqpit-config)
 [![CI](https://github.com/idiap/coqui-ai-coqpit/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/idiap/coqui-ai-coqpit/actions/workflows/main.yml)
 
 Simple, light-weight and no dependency config handling through python data

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -937,6 +937,7 @@ class Coqpit(Serializable, CoqpitType):
         Returns:
             List of unknown parameters.
         """
+        unknown: list[str] = []
         if not args:
             # If args was not specified, parse from sys.argv
             parser = self.init_argparse(instance=self, arg_prefix=arg_prefix, relaxed_parser=relaxed_parser)
@@ -948,7 +949,7 @@ class Coqpit(Serializable, CoqpitType):
             parser = self.init_argparse(instance=self, arg_prefix=arg_prefix, relaxed_parser=relaxed_parser)
             args, unknown = parser.parse_known_args(args)
 
-        self.parse_args(args)
+        self.parse_args(args, arg_prefix=arg_prefix)
         return unknown
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqpit-config"
-version = "0.1.0"
+version = "0.1.1"
 description = "Simple (maybe too simple), light-weight config management through python data-classes."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,44 @@
+from typing import Union
+
+from coqpit.coqpit import _is_optional_field, _is_union, _is_union_and_not_simple_optional
+
+# TODO: `type: ignore` can probably be removed when switching to Python 3.10
+#       Union syntax (e.g. str | int)
+
+
+def test_is_union() -> None:
+    cases = (
+        (Union[str, int], True),
+        (Union[str, None], True),
+        (int, False),
+        (list[int], False),
+        (list[Union[str, int]], False),
+    )
+    for item, expected in cases:
+        assert _is_union(item) == expected  # type: ignore[arg-type]
+
+
+def test_is_union_and_not_simple_optional() -> None:
+    cases = (
+        (Union[str, int], True),
+        (Union[str, None], False),
+        (Union[list[int], None], False),
+        (int, False),
+        (list[int], False),
+        (list[Union[str, int]], False),
+    )
+    for item, expected in cases:
+        assert _is_union_and_not_simple_optional(item) == expected  # type: ignore[arg-type]
+
+
+def test_is_optional_field() -> None:
+    cases = (
+        (Union[str, int], False),
+        (Union[str, None], True),
+        (Union[list[int], None], True),
+        (int, False),
+        (list[int], False),
+        (list[Union[str, int]], False),
+    )
+    for item, expected in cases:
+        assert _is_optional_field(item) == expected  # type: ignore[arg-type]


### PR DESCRIPTION
Small fix to correctly pass on the `arg_prefix` argument. The default in both functions is the same, so the behaviour doesn't change when it's left at the default.

Otherwise added some additional unit tests to check for correct behaviour.