### PR TITLE
Fix parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ lint:	## run ruff format and lint
 
 install:	## install 👩‍✈️ Coqpit for development.
 	uv sync --all-extras
-	uv runpre-commit install
+	uv run pre-commit install
 
 testlint: test lint

--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -596,7 +596,7 @@ def _add_argument(  # noqa: C901, PLR0913, PLR0912, PLR0915
         if _is_list(list_field_type) and relaxed_parser:
             return parser
 
-        if not has_default or field_default_factory is list:
+        if not has_default or default == []:
             if not _is_primitive_type(list_field_type) and not relaxed_parser:
                 msg = " [!] Empty list with non primitive inner type is currently not supported."
                 raise NotImplementedError(msg)
@@ -605,6 +605,7 @@ def _add_argument(  # noqa: C901, PLR0913, PLR0912, PLR0915
             parser.add_argument(
                 f"--{arg_prefix}",
                 nargs="*",
+                default=default,
                 type=list_field_type,
                 help=f"Coqpit Field: {help_prefix}",
             )
@@ -628,7 +629,7 @@ def _add_argument(  # noqa: C901, PLR0913, PLR0912, PLR0915
                 )
     # Fields matching: _T | list[_T] ( | None)
     elif (list_field_type := _parse_list_union(_drop_none_type(field_type))) is not None:
-        if not has_default or field_default_factory is list:
+        if not has_default or default == []:
             if not _is_primitive_type(list_field_type) and not relaxed_parser:
                 msg = " [!] Empty list with non primitive inner type is currently not supported."
                 raise NotImplementedError(msg)
@@ -637,6 +638,7 @@ def _add_argument(  # noqa: C901, PLR0913, PLR0912, PLR0915
             parser.add_argument(
                 f"--{arg_prefix}",
                 nargs="*",
+                default=default,
                 type=list_field_type,
                 help=f"Coqpit Field: {help_prefix}",
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqpit-config"
-version = "0.2.0"
+version = "0.2.1"
 description = "Simple (maybe too simple), light-weight config management through python data-classes."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -18,6 +18,7 @@ class SimpleConfig(Coqpit):
         default_factory=lambda: [SimplerConfig(val_a=100), SimplerConfig(val_a=999)],
         metadata={"help": "list of SimplerConfig"},
     )
+    int_list_empty_default: list[int] = field(default_factory=list)
     int_list: list[int] = field(default_factory=lambda: [1, 2, 3], metadata={"help": "int list"})
     str_list: list[str] = field(default_factory=lambda: ["veni", "vidi", "vici"], metadata={"help": "str"})
     empty_int_list: list[int] | None = field(default=None, metadata={"help": "int list without default value"})
@@ -29,6 +30,7 @@ class SimpleConfig(Coqpit):
     int_or_list: int | list[int] = field(default_factory=lambda: [1, 2, 3])
     float_or_list: float | list[float] = field(default=0.1)
     str_or_list: str | list[str] | None = field(default=None)
+    str_or_list_empty_default: str | list[str] | None = field(default_factory=list)
     bool_or_list: bool | list[bool] | None = field(default=None)
 
     # TODO: not supported yet
@@ -61,7 +63,7 @@ def test_parse_argparse() -> None:
     args.extend(["--coqpit.bool_or_list", "true"])
 
     # initial config
-    config = SimpleConfig()
+    config = SimpleConfig(int_list_empty_default=[55, 77], str_or_list_empty_default="a")
     config.pprint()
 
     # reference config that we like to match with the config above
@@ -71,6 +73,7 @@ def test_parse_argparse() -> None:
         val_c="this is different",
         val_dict={"val_a": 10, "val_b": 20},
         mylist_with_default=[SimplerConfig(val_a=222), SimplerConfig(val_a=111)],
+        int_list_empty_default=[55, 77],
         empty_int_list=[111, 222, 333],
         empty_str_list=["[foo=bar]", "[baz=qux]", "[blah,p=0.5,r=1~3]"],
         str_list=["neci", "vidi", "vici"],
@@ -79,6 +82,7 @@ def test_parse_argparse() -> None:
         int_or_list=[5, 2, 3],
         float_or_list=3.4,
         str_or_list=["a", "b"],
+        str_or_list_empty_default="a",
         bool_or_list=[True],
     )
 

--- a/tests/test_parse_known_argparse.py
+++ b/tests/test_parse_known_argparse.py
@@ -17,6 +17,8 @@ class SimpleConfig(Coqpit):
         default_factory=lambda: [SimplerConfig(val_a=100), SimplerConfig(val_a=999)],
         metadata={"help": "list of SimplerConfig"},
     )
+    int_list_empty_default: list[int] = field(default_factory=list)
+    str_or_list_empty_default: str | list[str] | None = field(default_factory=list)
 
     def check_values(self) -> None:
         """Check config fields"""
@@ -37,7 +39,7 @@ def test_parse_argparse() -> None:
     args.extend(unknown_args)
 
     # initial config
-    config = SimpleConfig()
+    config = SimpleConfig(int_list_empty_default=[55, 77], str_or_list_empty_default="a")
     config.pprint()
 
     # reference config that we like to match with the config above
@@ -46,6 +48,8 @@ def test_parse_argparse() -> None:
         val_b=999,
         val_c="this is different",
         mylist_with_default=[SimplerConfig(val_a=222), SimplerConfig(val_a=111)],
+        int_list_empty_default=[55, 77],
+        str_or_list_empty_default="a",
     )
 
     # create and init argparser with Coqpit


### PR DESCRIPTION
Ensures that non-empty list values are not dropped when parsing command-line arguments.