### PR TITLE
Deserialize nested optional Coqpit

### DIFF
--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -338,20 +338,21 @@ def _deserialize(x: Any, field_type: FieldType) -> Any:  # noqa: PLR0911
         object: deserialized object
 
     """
+    base_type = _drop_none_type(field_type)
     if isinstance(field_type, str):
         msg = "Strings as type hints are not supported."
         raise NotImplementedError(msg)
-    if _is_dict(_drop_none_type(field_type)):
+    if _is_dict(base_type):
         return _deserialize_dict(x)
-    if _is_list(_drop_none_type(field_type)):
-        return _deserialize_list(x, _drop_none_type(field_type))
+    if _is_list(base_type):
+        return _deserialize_list(x, base_type)
     if _is_union_and_not_simple_optional(field_type):
-        return _deserialize_union(x, field_type)  # ty: ignore[invalid-argument-type]
-    if not _is_union(field_type) and isinstance(field_type, type) and issubclass(field_type, Serializable):
-        return field_type.deserialize_immutable(x)
-    if _drop_none_type(field_type) is Path:
+        return _deserialize_union(x, field_type)
+    if not _is_union(base_type) and isinstance(base_type, type) and issubclass(base_type, Serializable):
+        return base_type.deserialize_immutable(x)
+    if base_type is Path:
         return _deserialize_path(x, field_type)
-    if _is_primitive_type(_drop_none_type(field_type)):
+    if _is_primitive_type(base_type):
         return _deserialize_primitive_types(x, field_type)
     if _is_literal_type(field_type):
         return _deserialize_literal(x, field_type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqpit-config"
-version = "0.2.3"
+version = "0.2.4"
 description = "Simple (maybe too simple), light-weight config management through python data-classes."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ skip_empty = true
 
 [tool.coverage.run]
 source = ["coqpit", "tests"]
-command_line = "-m pytest"
+command_line = "-m pytest -W error"
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_nested_configs.py
+++ b/tests/test_nested_configs.py
@@ -25,6 +25,8 @@ class NestedConfig(Coqpit):
     val_f: str = "Coqpit is great!"
     sc_list: list[SimpleConfig] | None = None
     sc: SimpleConfig = field(default_factory=lambda: SimpleConfig())
+    sc_optional: SimpleConfig | None = None
+    sc_optional2: SimpleConfig | None = field(default_factory=lambda: SimpleConfig())
     union_var: list[SimpleConfig] | SimpleConfig = field(default_factory=lambda: [SimpleConfig(), SimpleConfig()])
 
     def check_values(self) -> None:
@@ -44,9 +46,9 @@ def test_nested(tmp_path: Path) -> None:
 
     # save to a json file
     config.save_json(file_path)
-    # load a json file
+    # create a new config with different values than the defaults
     config2 = NestedConfig(val_e=500)
-    # update the config with the json file.
+    # update the config from the json file.
     config2.load_json(file_path)
     # now they should be having the same values.
     assert config == config2
@@ -56,9 +58,9 @@ def test_nested(tmp_path: Path) -> None:
 
     # export values to a dict
     config_dict = config.to_dict()
-    # crate a new config with different values than the defaults
+    # create a new config with different values than the defaults
     config2 = NestedConfig(val_e=500)
-    # update the config with the exported valuess from the previous config.
+    # update the config with the exported values from the previous config.
     config2.from_dict(config_dict)
     # now they should be having the same values.
     assert config == config2

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "coqpit-config"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
The code below, where a Coqpit contains an optional nested Coqpit (`sub_config: Config | None = None`), previously failed with:

```python
./coqpit/coqpit.py:861: UserWarning: Type mismatch in NestedConfig
Failed to deserialize field: sub_config (__main__.Config | None) = {'val': 10}
Type '<class 'dict'>' of value '{'val': 10}' does not match declared '__main__.Config | None' field type.
Replaced it with field's default value: None
  self.deserialize(data)
Traceback (most recent call last):
    assert nc == nc2
           ^^^^^^^^^
AssertionError
```

With this PR, such a nested Coqpit is deserialised correctly.

```python
from dataclasses import dataclass

from coqpit import Coqpit

@dataclass
class Config(Coqpit):
    val: int = 10

@dataclass
class NestedConfig(Coqpit):
    sub_config: Config | None = None

nc = NestedConfig(sub_config=Config())
nc2 = NestedConfig()
nc2.from_dict(nc.to_dict())

assert nc == nc2
```