### PR TITLE
Handle literals when parsing arguments

### DIFF
--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -687,6 +687,19 @@ def _add_argument(  # noqa: C901, PLR0913, PLR0912, PLR0915
         if not relaxed_parser:
             msg = " [!] Parsing `Union` field from argparse is not yet implemented. Please create an issue."
             raise NotImplementedError(msg)
+    elif _is_literal_type(field_type):
+        type_args = typing.get_args(field_type)
+        literal_type = type(type_args[0])
+        if not all(type(x) is literal_type for x in type_args):
+            msg = "Mixing literals of different types is not supported."
+            raise TypeError(msg)
+        parser.add_argument(
+            f"--{arg_prefix}",
+            default=field_default,
+            type=literal_type,
+            choices=type_args,
+            help=f"Coqpit Field: {help_prefix}",
+        )
     elif not _is_union(field_type) and issubclass(field_type, Coqpit):
         if not isinstance(default, Coqpit):
             msg = f"Default value must be a Coqpit instance, got {default}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coqpit-config"
-version = "0.2.4"
+version = "0.2.5"
 description = "Simple (maybe too simple), light-weight config management through python data-classes."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_parse_argparse.py
+++ b/tests/test_parse_argparse.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict, dataclass, field
+from typing import Literal
 
 from coqpit.coqpit import Coqpit, check_argument
 
@@ -32,6 +33,8 @@ class SimpleConfig(Coqpit):
     str_or_list: str | list[str] | None = field(default=None)
     str_or_list_empty_default: str | list[str] | None = field(default_factory=list)
     bool_or_list: bool | list[bool] | None = field(default=None)
+    str_literal: Literal["A", "B"] = "B"
+    int_literal: Literal[1, 2] = 2
 
     # TODO: not supported yet
     # mylist_without_default: List[SimplerConfig] = field(default=None)  noqa: ERA001
@@ -61,6 +64,8 @@ def test_parse_argparse() -> None:
     args.extend(["--coqpit.float_or_list", "3.4"])
     args.extend(["--coqpit.str_or_list", "a", "b"])
     args.extend(["--coqpit.bool_or_list", "true"])
+    args.extend(["--coqpit.str_literal", "A"])
+    args.extend(["--coqpit.int_literal", "1"])
 
     # initial config
     config = SimpleConfig(int_list_empty_default=[55, 77], str_or_list_empty_default="a")
@@ -84,6 +89,8 @@ def test_parse_argparse() -> None:
         str_or_list=["a", "b"],
         str_or_list_empty_default="a",
         bool_or_list=[True],
+        str_literal="A",
+        int_literal=1,
     )
 
     # create and init argparser with Coqpit

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "coqpit-config"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
#11 added support for `Literal` types, but they couldn't be parsed by `argparse` yet.